### PR TITLE
Add end session when reading

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -53,6 +53,13 @@ class CelikAPI {
       ...portrait,
     }
 
+    const endRead = this.api.EidEndRead();
+    console.log(`EidEndRead: ${endRead}`);
+
+    if (endRead != 0) {
+      throw new Error(`Error code: ${endRead}`);
+    }
+
     return data;
   }
 


### PR DESCRIPTION
When reading an ID card, the session is opened with 'EidBeginRead()' and needs to be closed with 'EidEndRead()' to be able to read another ID card.